### PR TITLE
Inititialise mission cleanup

### DIFF
--- a/src/isar_exr/api/energy_robotics_api.py
+++ b/src/isar_exr/api/energy_robotics_api.py
@@ -531,7 +531,7 @@ class EnergyRoboticsApi:
         except Exception as e:
             message: str = "Could not check robot battery level"
             self.logger.error(message)
-            raise RobotMissionStatusException(
+            raise RobotMissionStatusException( #TODO: occurs after obstacle
                 error_description=message,
             )
 

--- a/src/isar_exr/api/energy_robotics_api.py
+++ b/src/isar_exr/api/energy_robotics_api.py
@@ -531,7 +531,7 @@ class EnergyRoboticsApi:
         except Exception as e:
             message: str = "Could not check robot battery level"
             self.logger.error(message)
-            raise RobotMissionStatusException( #TODO: occurs after obstacle
+            raise RobotMissionStatusException(  # TODO: occurs after obstacle
                 error_description=message,
             )
 

--- a/src/isar_exr/config/maps/exr_jca_ap.json
+++ b/src/isar_exr/config/maps/exr_jca_ap.json
@@ -1,0 +1,95 @@
+{
+  "name": "exr_jca_ap",
+  "map_from": {
+    "name": "robot",
+    "reference_positions": {
+      "positions": [
+        {
+          "x": 0.11907593905116448,
+          "y": 0.8190074941458545,
+          "z": -0.176361,
+          "frame": {
+            "name": "robot"
+          }
+        },
+        {
+          "x": 4.8833662578143295,
+          "y": -18.191902104254204,
+          "z": -0.12536099999999806,
+          "frame": {
+            "name": "robot"
+          }
+        },
+        {
+          "x": 26.66857454840731,
+          "y": -10.294643102836075,
+          "z": 1.489639000000004,
+          "frame": {
+            "name": "robot"
+          }
+        }
+      ],
+      "frame": {
+        "name": "robot"
+      }
+    },
+    "frame": {
+      "name": "robot"
+    }
+  },
+  "map_to": {
+    "name": "asset",
+    "reference_positions": {
+      "positions": [
+        {
+          "x": 247.453,
+          "y": 322.511,
+          "z": 36.001,
+          "frame": {
+            "name": "asset"
+          }
+        },
+        {
+          "x": 228.668,
+          "y": 316.922,
+          "z": 36.052,
+          "frame": {
+            "name": "asset"
+          }
+        },
+        {
+          "x": 237.508,
+          "y": 295.502,
+          "z": 37.667,
+          "frame": {
+            "name": "asset"
+          }
+        }
+      ],
+      "frame": {
+        "name": "asset"
+      }
+    },
+    "frame": {
+      "name": "asset"
+    },
+    "bounds": {
+      "position1": {
+        "x": -1000,
+        "y": -1000,
+        "z": -10,
+        "frame": {
+          "name": "asset"
+        }
+      },
+      "position2": {
+        "x": 5000,
+        "y": 1000,
+        "z": 1000,
+        "frame": {
+          "name": "asset"
+        }
+      }
+    }
+  }
+}

--- a/src/isar_exr/config/settings.py
+++ b/src/isar_exr/config/settings.py
@@ -16,16 +16,16 @@ class Settings(BaseSettings):
         super().__init__(_env_file=env_file_path)
 
     # The ID of the robot in the EXR database
-    ROBOT_EXR_ID: str = Field(default="628787246cc0c0205c56e88e")
+    ROBOT_EXR_ID: str = Field(default="61a09ebc5f71911c10b463ce")
 
     # The ID of the docking station in the EXR database
-    DOCKING_STATION_ID: str = Field(default="65cb874690e6878851ddc236")
+    DOCKING_STATION_ID: str = Field(default="65153c6893a0ba5b7b487b6e")
 
     # The ID of the relevant site in the EXR database (default=KAA)
-    ROBOT_EXR_SITE_ID: str = Field(default="65cb3a3946b245d013c0e2ff")
+    ROBOT_EXR_SITE_ID: str = Field(default="61a0a1f45f71913ebbb4657d")
 
     # Map to be used for creation of alitra transformation
-    MAP: str = Field(default="exr_jca_ap")
+    MAP: str = Field(default="exr_klab_sst")
 
     # URL for Ex-Robotics API
     ROBOT_API_URL: str = Field(default="https://developer.energy-robotics.com/graphql/")

--- a/src/isar_exr/config/settings.py
+++ b/src/isar_exr/config/settings.py
@@ -16,16 +16,16 @@ class Settings(BaseSettings):
         super().__init__(_env_file=env_file_path)
 
     # The ID of the robot in the EXR database
-    ROBOT_EXR_ID: str = Field(default="61a09ebc5f71911c10b463ce")
+    ROBOT_EXR_ID: str = Field(default="628787246cc0c0205c56e88e")
 
     # The ID of the docking station in the EXR database
-    DOCKING_STATION_ID: str = Field(default="65153c6893a0ba5b7b487b6e")
+    DOCKING_STATION_ID: str = Field(default="65cb874690e6878851ddc236")
 
     # The ID of the relevant site in the EXR database (default=KAA)
-    ROBOT_EXR_SITE_ID: str = Field(default="61a0a1f45f71913ebbb4657d")
+    ROBOT_EXR_SITE_ID: str = Field(default="65cb3a3946b245d013c0e2ff")
 
     # Map to be used for creation of alitra transformation
-    MAP: str = Field(default="exr_klab_sst")
+    MAP: str = Field(default="exr_jca_ap")
 
     # URL for Ex-Robotics API
     ROBOT_API_URL: str = Field(default="https://developer.energy-robotics.com/graphql/")

--- a/src/isar_exr/robotinterface.py
+++ b/src/isar_exr/robotinterface.py
@@ -95,7 +95,7 @@ class Robot(RobotInterface):
         stage_id: str = self.api.create_stage(site_id=settings.ROBOT_EXR_SITE_ID)
         return stage_id
 
-    def update_site_with_tasks(self, tasks) -> List[str]: # Returns a list of POI IDs
+    def update_site_with_tasks(self, tasks: List[Task]) -> List[str]: # Returns a list of POI IDs
         new_stage_id = None
         poi_ids: List[str] = []
         is_possible_return_to_home_mission = False
@@ -137,7 +137,7 @@ class Robot(RobotInterface):
 
             if steps_n == 0 or (steps_n == 1 and is_possible_return_to_home_mission):
                 time.sleep(settings.API_SLEEP_TIME) # We need to sleep to allow events to reach flotilla in the right order
-                raise RobotMissionNotSupportedException()
+                raise RobotMissionNotSupportedException("Robot does not support localisation or return to home mission")
 
             if new_stage_id is not None:
                 # We should only do the following if we changed the site
@@ -157,20 +157,16 @@ class Robot(RobotInterface):
             ):
                 time.sleep(settings.API_SLEEP_TIME)
         return poi_ids
-
-    def initiate_mission(self, mission: Mission) -> None:
-        try:
-            poi_ids: List[str] = self.update_site_with_tasks(mission.tasks)
-        except RobotMissionNotSupportedException:
-            return
-
+    
+    def create_mission_definition(self, mission_name: str, tasks: List[Task], poi_ids: List[str]) -> str: # Returns a mission definition ID
+        # Note that the POI IDs need to be in the same order as inspection steps in the provided mission
         mission_definition_id: str = self.api.create_mission_definition(
             site_id=settings.ROBOT_EXR_SITE_ID,
-            mission_name=mission.id,
+            mission_name=mission_name,
             robot_id=settings.ROBOT_EXR_ID,
         )
 
-        for task in mission.tasks:
+        for task in tasks:
             for step in task.steps:
                 if isinstance(step, DriveToPose):
                     self._add_waypoint_task_to_mission(
@@ -187,6 +183,17 @@ class Robot(RobotInterface):
             task_name="dock",
             mission_definition_id=mission_definition_id,
         )
+        return mission_definition_id
+
+    def initiate_mission(self, mission: Mission) -> None:
+        try:
+            poi_ids: List[str] = self.update_site_with_tasks(mission.tasks)
+        except RobotMissionNotSupportedException:
+            return
+        except Exception as e:
+            raise e
+
+        mission_definition_id: str = self.create_mission_definition(mission.id, mission.tasks, poi_ids)
 
         self.api.start_mission_execution(
             mission_definition_id=mission_definition_id, robot_id=settings.ROBOT_EXR_ID

--- a/src/isar_exr/robotinterface.py
+++ b/src/isar_exr/robotinterface.py
@@ -87,11 +87,15 @@ class Robot(RobotInterface):
             map_alignment.map_from, map_alignment.map_to, rot_axes="z"
         )
 
-    def initiate_mission(self, mission: Mission) -> None:
-        curent_stage_id = self.api.get_current_site_stage(settings.ROBOT_EXR_SITE_ID)
-        if curent_stage_id is not None:
-            self.api.discard_stage(stage_id=curent_stage_id)
+    def create_new_stage(self) -> str:
+        current_stage_id = self.api.get_current_site_stage(settings.ROBOT_EXR_SITE_ID)
+        if current_stage_id is not None:
+            self.api.discard_stage(stage_id=current_stage_id)
         stage_id: str = self.api.create_stage(site_id=settings.ROBOT_EXR_SITE_ID)
+        return stage_id
+
+    def initiate_mission(self, mission: Mission) -> None:
+        stage_id: str = self.create_new_stage()
 
         updating_site = False
         poi_ids: List[str] = []
@@ -119,10 +123,10 @@ class Robot(RobotInterface):
                     )
                     if existing_poi_id == None:
                         poi_id: str = (
-                            self._create_and_add_poi(  # Here we should only create if it does not already exist
+                            self._create_and_add_poi(
                                 task=task,
                                 step=step,
-                                robot_pose=robot_pose,
+                                robot_pose=robot_pose, # This pose is set by the previously received DriveToStep
                                 stage_id=stage_id,
                             )
                         )


### PR DESCRIPTION
Most importantly, this PR tries to reduce the possibility of a stage not being closed after being opened, as this can cause other inconsistencies. Besides this the PR also changes the default robot location away from KAA.